### PR TITLE
Change CTA to just comment on Lenster

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,47 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at newt@aave.com. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see https://www.contributor-covenant.org/faq

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ Contract address: [0x432960b3209686cc69e2eec1dbbab52a1c0bf938](https://polygonsc
 
 ## User guide
 
-We uploaded a step-by-step user guide for anyone (technical and non-technical peeps) to use re:meme. Check them out on Lenstube:
+We uploaded a [step-by-step user guide](https://wearenewt.xyz/roadmap/lens-memixer/rememe-user-guide) for anyone to use re:meme.
+
+You can also check out user guide videos on Lenstube:
 
 1. How to [discover and share memes](https://lenstube.xyz/watch/0xf803-0x02)
 1. How to [remix memes](https://lenstube.xyz/watch/0xf803-0x03)

--- a/frontend/components/Remix/RemixShareBox/index.tsx
+++ b/frontend/components/Remix/RemixShareBox/index.tsx
@@ -26,7 +26,7 @@ export const RemixShareBox : React.FC<RemixShareBoxProps> = ({ publication }) =>
 
     return (
         <div className="main-container">
-            <a target="_blank" rel="noreferrer" href={`${selectedEnvironment.lensterUrl}/posts/${publication.id}`} className="btn-medium-secondary no-underline hover:text-neutral-black w-full mb-[16px]">Collect/comment on Lenster</a>
+            <a target="_blank" rel="noreferrer" href={`${selectedEnvironment.lensterUrl}/posts/${publication.id}`} className="btn-medium-secondary no-underline hover:text-neutral-black w-full mb-[16px]">Comment on Lenster</a>
             <div className="flex justify-center gap-[12px]">
                 <div key={"sicon-share"} onClick={handleShare} className="icon-btn-medium-secondary">
                     <img className="icon-md" src="/assets/icons/share-icon.svg" alt="share" />


### PR DESCRIPTION
Per Stani's feedback, changed 'collect/comment on Lenster' to just 'comment on Lenster' because
1. dual CTA (call to action is confusing)
2. collect on Lenster is not live yet